### PR TITLE
chore: merge Lefthook pre-commit commands and restructure Gradle conventions

### DIFF
--- a/gradle/build-logic/src/main/groovy/com.kachnic.format-common-conventions.gradle
+++ b/gradle/build-logic/src/main/groovy/com.kachnic.format-common-conventions.gradle
@@ -1,0 +1,7 @@
+plugins {
+	id 'com.diffplug.spotless'
+}
+
+spotless {
+	ratchetFrom 'origin/main'
+}

--- a/gradle/build-logic/src/main/groovy/com.kachnic.format-java-conventions.gradle
+++ b/gradle/build-logic/src/main/groovy/com.kachnic.format-java-conventions.gradle
@@ -1,10 +1,5 @@
-plugins {
-    id 'com.diffplug.spotless'
-}
-
 spotless {
-    ratchetFrom 'origin/main'
-    java {
-        palantirJavaFormat(libs.versions.palantirJavaFormat.get())
-    }
+	java {
+		palantirJavaFormat(libs.versions.palantirJavaFormat.get())
+	}
 }

--- a/gradle/build-logic/src/main/groovy/com.kachnic.format-misc-conventions.gradle
+++ b/gradle/build-logic/src/main/groovy/com.kachnic.format-misc-conventions.gradle
@@ -1,14 +1,8 @@
-plugins {
-    id 'com.diffplug.spotless'
-}
+import com.kachnic.gradle.format.SpotlessConfig
 
 spotless {
-    ratchetFrom 'origin/main'
-    format 'misc', {
-        target '*.gradle', '.gitattributes', '.gitignore'
-
-        trimTrailingWhitespace()
-        leadingSpacesToTabs()
-        endWithNewline()
-    }
+	format 'misc', {
+		target '*.gradle', '.gitattributes', '.gitignore'
+		SpotlessConfig.applyCommonFormatting(delegate)
+	}
 }

--- a/gradle/build-logic/src/main/groovy/com.kachnic.java-conventions.gradle
+++ b/gradle/build-logic/src/main/groovy/com.kachnic.java-conventions.gradle
@@ -1,30 +1,31 @@
 plugins {
-    id 'com.kachnic.java-common-conventions'
-    id 'com.kachnic.format-java-conventions'
-    id 'com.kachnic.format-misc-conventions'
-    id 'pmd'
-    id 'com.github.spotbugs'
+	id 'com.kachnic.java-common-conventions'
+	id 'com.kachnic.format-common-conventions'
+	id 'com.kachnic.format-java-conventions'
+	id 'com.kachnic.format-misc-conventions'
+	id 'pmd'
+	id 'com.github.spotbugs'
 }
 
 pmd {
-    toolVersion = libs.versions.pmd.get()
-    consoleOutput = true
-    incrementalAnalysis = true
-    ruleSetConfig = resources.text.fromUri(this.class.getResource('pmd/ruleset.xml'))
-    ruleSets = []
+	toolVersion = libs.versions.pmd.get()
+	consoleOutput = true
+	incrementalAnalysis = true
+	ruleSetConfig = resources.text.fromUri(this.class.getResource('pmd/ruleset.xml'))
+	ruleSets = []
 }
 
 tasks.named('pmdMain') {
-    group = 'verification'
+	group = 'verification'
 }
 
 tasks.named('pmdTest') {
-    group = 'verification'
+	group = 'verification'
 }
 
 tasks.register('formatAndAnalyze') {
-    group = 'verification'
-    description = 'Apply Spotless formatting and run PMD and SpotBugs analysis.'
+	group = 'verification'
+	description = 'Apply Spotless formatting and run PMD and SpotBugs analysis.'
 
-    dependsOn 'spotlessApply', 'pmdMain', 'pmdTest', 'spotbugsMain', 'spotbugsTest'
+	dependsOn 'spotlessApply', 'pmdMain', 'pmdTest', 'spotbugsMain', 'spotbugsTest'
 }

--- a/gradle/build-logic/src/main/groovy/com.kachnic.root-conventions.gradle
+++ b/gradle/build-logic/src/main/groovy/com.kachnic.root-conventions.gradle
@@ -1,4 +1,14 @@
+import com.kachnic.gradle.format.SpotlessConfig
+
 plugins {
-    id 'com.kachnic.format-misc-conventions'
-    id 'com.kachnic.sonar-conventions'
+	id 'com.kachnic.format-common-conventions'
+	id 'com.kachnic.format-misc-conventions'
+	id 'com.kachnic.sonar-conventions'
+}
+
+spotless {
+	format('buildLogic') {
+		target 'gradle/build-logic/**/*.gradle'
+		SpotlessConfig.applyCommonFormatting(delegate)
+	}
 }

--- a/gradle/build-logic/src/main/groovy/com.kachnic.test-coverage-conventions.gradle
+++ b/gradle/build-logic/src/main/groovy/com.kachnic.test-coverage-conventions.gradle
@@ -1,28 +1,26 @@
 plugins {
-    id 'jacoco'
+	id 'jacoco'
 }
 
 jacoco {
-    toolVersion = libs.versions.jacoco.get()
+	toolVersion = libs.versions.jacoco.get()
 }
 
 tasks.named('jacocoTestReport') {
-    dependsOn tasks.withType(Test)
+	dependsOn tasks.withType(Test)
 
-    reports {
-        html.required = true
-        xml.required = true
-    }
+	reports {
+		html.required = true
+		xml.required = true
+	}
 }
-
 
 tasks.named('jacocoTestCoverageVerification') {
-    violationRules {
-        rule {
-            limit {
-                minimum = 0.8
-            }
-        }
-    }
+	violationRules {
+		rule {
+			limit {
+				minimum = 0.8
+			}
+		}
+	}
 }
-

--- a/gradle/build-logic/src/main/groovy/com/kachnic/gradle/format/SpotlessConfig.groovy
+++ b/gradle/build-logic/src/main/groovy/com/kachnic/gradle/format/SpotlessConfig.groovy
@@ -1,0 +1,12 @@
+package com.kachnic.gradle.format
+
+import com.diffplug.gradle.spotless.FormatExtension
+
+class SpotlessConfig {
+    static void applyCommonFormatting(FormatExtension format) {
+        format.trimTrailingWhitespace()
+        format.leadingSpacesToTabs()
+        format.endWithNewline()
+    }
+}
+

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -6,32 +6,13 @@ pre-commit:
   parallel: true
 
   commands:
-    frontend-lint-format-js:
-      glob: 'frontend/*/*.{js,jsx}'
+    project-lint-format-js:
+      glob: '*.{js,jsx}'
       run: '{lint} {staged_files} && {format} {staged_files}'
       stage_fixed: true
 
-    frontend-format-html-css-json:
-      glob: 'frontend/*/*.{html,css,json}'
-      run: '{format} {staged_files}'
-      stage_fixed: true
-
-    root-lint-format-js:
-      glob: '*.js'
-      exclude:
-        - '*/*'
-      run: '{lint} {staged_files} && {format} {staged_files}'
-      stage_fixed: true
-
-    root-format-json-yml:
-      glob: '*.{json,yml}'
-      exclude:
-        - '*/*'
-      run: '{format} {staged_files}'
-      stage_fixed: true
-
-    workflow-format-yml:
-      glob: '.github/*.yml'
+    project-format-html-css-json-yml:
+      glob: '*.{html,css,json,yml}'
       run: '{format} {staged_files}'
       stage_fixed: true
 
@@ -47,6 +28,8 @@ gradle-pipe:
       run: ./gradlew formatAndAnalyze
     gradle-root-misc-format:
       run: ./gradlew :spotlessMiscApply
+    gradle-build-logic-format:
+      run: ./gradlew :spotlessBuildLogicApply
 
 commit-msg:
   commands:


### PR DESCRIPTION
### Summary
Modify lefthook.yml to merge the frontend and root Lefthook pre-commit commands into project commands that runs globally, ensuring commands execute consistently regardless of the directory.

Add spotless { format("buildLogic") } to the root conventions to apply formatting rules to build-logic files and maintain a consistent Gradle style.

Restructure Gradle convention plugins by introducing format-common-conventions.gradle to centralize and clarify formatting conventions.