### PR TITLE
chore: set up Docker Compose, API docs, and secure transitive deps

### DIFF
--- a/backend/app/build.gradle
+++ b/backend/app/build.gradle
@@ -3,6 +3,7 @@ plugins {
 	alias(libs.plugins.test.coverage.conventions)
 	alias(libs.plugins.spring.boot)
 	alias(libs.plugins.spring.dependency.management)
+	alias(libs.plugins.transitive.dependency.conventions)
 }
 
 group = 'com.kachnic'
@@ -15,11 +16,13 @@ configurations {
 }
 
 dependencies {
+	implementation(platform(libs.springdoc.bom))
 	implementation(libs.spring.boot.starter.data.jpa)
 	implementation(libs.spring.boot.starter.security)
 	implementation(libs.spring.boot.starter.web)
 	implementation(libs.flyway.core)
 	implementation(libs.flyway.postgresql)
+	implementation(libs.springdoc.openapi.starter.webmvc.ui)
 	compileOnly(libs.lombok)
 	developmentOnly(libs.spring.boot.devtools)
 	developmentOnly(libs.spring.boot.docker.compose)

--- a/backend/app/build.gradle
+++ b/backend/app/build.gradle
@@ -22,6 +22,7 @@ dependencies {
 	implementation(libs.flyway.postgresql)
 	compileOnly(libs.lombok)
 	developmentOnly(libs.spring.boot.devtools)
+	developmentOnly(libs.spring.boot.docker.compose)
 	runtimeOnly(libs.postgresql)
 	annotationProcessor(libs.lombok)
 	testImplementation(libs.spring.boot.starter.test)

--- a/backend/app/docker-compose.yml
+++ b/backend/app/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  postgres-dev:
+    image: postgres:17.5
+    container_name: postgres-dev
+    restart: always
+    environment:
+      POSTGRES_DB: dev_db
+      POSTGRES_USER: dev_user
+      POSTGRES_PASSWORD: dev_pass
+    ports:
+      - '5432:5432'
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+volumes:
+  postgres_data:

--- a/backend/app/src/main/resources/application.properties
+++ b/backend/app/src/main/resources/application.properties
@@ -1,3 +1,7 @@
 # --- Shared settings
 spring.application.name=RtChats
 spring.profiles.active=${PROFILE_ACTIVE:dev}
+
+# Docs
+springdoc.api-docs.path=/api-docs
+springdoc.swagger-ui.path=/api-docs/swagger-ui

--- a/e2e/build.gradle
+++ b/e2e/build.gradle
@@ -1,6 +1,7 @@
 plugins {
 	alias(libs.plugins.java.conventions)
 	alias(libs.plugins.cucumber.companion)
+	alias(libs.plugins.transitive.dependency.conventions)
 }
 
 group = 'com.kachnic'
@@ -31,15 +32,6 @@ dependencies {
 	testImplementation(libs.webdrivermanager)
 
 	testRuntimeOnly(libs.junit.platform.launcher)
-}
-
-configurations.configureEach {
-	resolutionStrategy.eachDependency {
-		if (requested.group == "org.apache.commons" && requested.name == "commons-lang3") {
-			useVersion(libs.versions.commonsLang3.get())
-			because("Force secure version due to CVE")
-		}
-	}
 }
 
 tasks.named('test') {

--- a/gradle/build-logic/src/main/groovy/com.kachnic.transitive-dependency-conventions.gradle
+++ b/gradle/build-logic/src/main/groovy/com.kachnic.transitive-dependency-conventions.gradle
@@ -1,0 +1,8 @@
+project.configurations.configureEach {
+	resolutionStrategy.eachDependency {
+		if (requested.group == "org.apache.commons" && requested.name == "commons-lang3") {
+			useVersion(libs.versions.commonsLang3.get())
+			because("Force secure version due to CVE")
+		}
+	}
+}

--- a/gradle/build-logic/src/main/groovy/com.kachnic.transitive-dependency-conventions.gradle
+++ b/gradle/build-logic/src/main/groovy/com.kachnic.transitive-dependency-conventions.gradle
@@ -1,4 +1,4 @@
-project.configurations.configureEach {
+configurations.configureEach {
 	resolutionStrategy.eachDependency {
 		if (requested.group == "org.apache.commons" && requested.name == "commons-lang3") {
 			useVersion(libs.versions.commonsLang3.get())

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,7 @@ spotless-gradle = { group = "com.diffplug.spotless", name = "spotless-plugin-gra
 spotbugs-gradle = { group = "com.github.spotbugs", name = "com.github.spotbugs.gradle.plugin", version.ref = "spotbugs" }
 sonarqube-gradle = { group = "org.sonarsource.scanner.gradle", name = "sonarqube-gradle-plugin", version.ref = "sonarqube" }
 
+spring-boot-docker-compose = { group = "org.springframework.boot", name = "spring-boot-docker-compose" }
 spring-boot-starter-data-jpa = { group = "org.springframework.boot", name = "spring-boot-starter-data-jpa" }
 spring-boot-starter-security = { group = "org.springframework.boot", name = "spring-boot-starter-security" }
 spring-boot-starter-web = { group = "org.springframework.boot", name = "spring-boot-starter-web" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ webdrivermanager = "6.1.1"
 commonsLang3 = "3.18.0"
 jacoco = "0.8.13"
 sonarqube = "6.2.0.5505"
+springdoc = "2.8.9"
 
 [libraries]
 spotless-gradle = { group = "com.diffplug.spotless", name = "spotless-plugin-gradle", version.ref = "spotless" }
@@ -37,6 +38,9 @@ testcontainers-postgresql = { group = "org.testcontainers", name = "postgresql" 
 junit-platform-launcher = { group = "org.junit.platform", name = "junit-platform-launcher" }
 flyway-core = { group = "org.flywaydb", name = "flyway-core" }
 flyway-postgresql = { group = "org.flywaydb", name = "flyway-database-postgresql" }
+
+springdoc-bom = { group = "org.springdoc", name = "springdoc-openapi-bom", version.ref = "springdoc" }
+springdoc-openapi-starter-webmvc-ui = { group = "org.springdoc", name = "springdoc-openapi-starter-webmvc-ui" }
 
 restassured-bom = { group = "io.rest-assured", name = "rest-assured-bom", version.ref = "restAssured" }
 junit-bom = { group = "org.junit", name = "junit-bom", version.ref = "junit" }
@@ -64,6 +68,8 @@ groovy-gradle = { id = "groovy-gradle-plugin" }
 root-conventions = { id = "com.kachnic.root-conventions"}
 java-conventions = { id = "com.kachnic.java-conventions" }
 test-coverage-conventions = { id = "com.kachnic.test-coverage-conventions" }
+transitive-dependency-conventions = { id = "com.kachnic.transitive-dependency-conventions" }
+
 spring-boot = { id = "org.springframework.boot", version.ref = "springBoot" }
 spring-dependency-management = { id = "io.spring.dependency-management", version.ref = "springDependencyManagement" }
 


### PR DESCRIPTION
### Summary

Add a Docker Compose dependency to the backend app using docker-compose.yml for automatically starting and stopping containers (including PostgreSQL) during development.

Add Springdoc with Swagger dependency and configure documentation URLs: /api-docs and /api-docs/swagger-ui for automatic API documentation generation.

Add the transitive-dependency-conventions plugin to ensure transitive dependencies do not contain vulnerabilities.