### PR TITLE
Add time limit specification and prevent REDOS

### DIFF
--- a/backend/app/src/main/java/com/kachnic/rtchats/libs/ddd/exceptions/DomainException.java
+++ b/backend/app/src/main/java/com/kachnic/rtchats/libs/ddd/exceptions/DomainException.java
@@ -10,4 +10,8 @@ public class DomainException extends RuntimeException {
     public DomainException(final String message) {
         super(message);
     }
+
+    public DomainException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
 }

--- a/backend/app/src/main/java/com/kachnic/rtchats/libs/ddd/exceptions/InternalServerException.java
+++ b/backend/app/src/main/java/com/kachnic/rtchats/libs/ddd/exceptions/InternalServerException.java
@@ -1,0 +1,14 @@
+package com.kachnic.rtchats.libs.ddd.exceptions;
+
+import java.io.Serial;
+
+public class InternalServerException extends DomainException {
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    private static final String MESSAGE = "Internal Server Error";
+
+    public InternalServerException(final Throwable cause) {
+        super(MESSAGE, cause);
+    }
+}

--- a/backend/app/src/main/java/com/kachnic/rtchats/libs/ddd/exceptions/TimeLimitExceededException.java
+++ b/backend/app/src/main/java/com/kachnic/rtchats/libs/ddd/exceptions/TimeLimitExceededException.java
@@ -1,0 +1,12 @@
+package com.kachnic.rtchats.libs.ddd.exceptions;
+
+import java.io.Serial;
+
+public class TimeLimitExceededException extends DomainException {
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    public TimeLimitExceededException(final String message) {
+        super(message);
+    }
+}

--- a/backend/app/src/main/java/com/kachnic/rtchats/libs/ddd/specs/BetweenLengthSpecification.java
+++ b/backend/app/src/main/java/com/kachnic/rtchats/libs/ddd/specs/BetweenLengthSpecification.java
@@ -3,7 +3,14 @@ package com.kachnic.rtchats.libs.ddd.specs;
 import com.kachnic.rtchats.libs.ddd.DomainValidate;
 import com.kachnic.rtchats.libs.ddd.exceptions.ArgumentOutOfRangeException;
 
-public record BetweenLengthSpecification(int minLength, int maxLength) implements Specification<String> {
+public final class BetweenLengthSpecification implements Specification<String> {
+    private final int minLength;
+    private final int maxLength;
+
+    public BetweenLengthSpecification(final int minLength, final int maxLength) {
+        this.minLength = minLength;
+        this.maxLength = maxLength;
+    }
 
     public static BetweenLengthSpecification of(final int minLength, final int maxLength) {
         return new BetweenLengthSpecification(minLength, maxLength);

--- a/backend/app/src/main/java/com/kachnic/rtchats/libs/ddd/specs/MatchesFormatSpecification.java
+++ b/backend/app/src/main/java/com/kachnic/rtchats/libs/ddd/specs/MatchesFormatSpecification.java
@@ -2,20 +2,52 @@ package com.kachnic.rtchats.libs.ddd.specs;
 
 import com.kachnic.rtchats.libs.ddd.DomainValidate;
 import com.kachnic.rtchats.libs.ddd.exceptions.ArgumentInvalidFormatException;
+import com.kachnic.rtchats.libs.ddd.exceptions.TimeLimitExceededException;
 import java.util.regex.Pattern;
 
-public record MatchesFormatSpecification(Pattern pattern) implements Specification<String> {
+public final class MatchesFormatSpecification implements Specification<String> {
+    private final Pattern pattern;
+
+    private MatchesFormatSpecification(final Pattern pattern) {
+        this.pattern = pattern;
+    }
+
     public static MatchesFormatSpecification of(final Pattern pattern) {
         return new MatchesFormatSpecification(pattern);
     }
 
     @Override
-    public void check(final String value, final String paramName) {
-        DomainValidate.ifTrue(isInvalidFormat(value))
-                .thenThrow(() -> new ArgumentInvalidFormatException(paramName, value));
+    public void check(final String candidate, final String paramName) {
+        DomainValidate.ifTrue(isInvalidFormat(candidate))
+                .thenThrow(() -> new ArgumentInvalidFormatException(paramName, candidate));
     }
 
     private boolean isInvalidFormat(final String value) {
-        return !pattern.matcher(value).matches();
+        final CharSequence sequence = new InterruptibleCharSequence(value);
+        return !pattern.matcher(sequence).matches();
+    }
+
+    private record InterruptibleCharSequence(CharSequence inner) implements CharSequence {
+        private static final String TIMEOUT_MESSAGE =
+                "Regex evaluation was interrupted due to task timeout or cancellation";
+
+        @Override
+        public int length() {
+            return inner.length();
+        }
+
+        @Override
+        public char charAt(final int index) {
+            if (Thread.currentThread().isInterrupted()) {
+                throw new TimeLimitExceededException(TIMEOUT_MESSAGE);
+            }
+
+            return inner.charAt(index);
+        }
+
+        @Override
+        public CharSequence subSequence(final int start, final int end) {
+            return inner.subSequence(start, end);
+        }
     }
 }

--- a/backend/app/src/main/java/com/kachnic/rtchats/libs/ddd/specs/MaxLengthSpecification.java
+++ b/backend/app/src/main/java/com/kachnic/rtchats/libs/ddd/specs/MaxLengthSpecification.java
@@ -3,7 +3,13 @@ package com.kachnic.rtchats.libs.ddd.specs;
 import com.kachnic.rtchats.libs.ddd.DomainValidate;
 import com.kachnic.rtchats.libs.ddd.exceptions.ArgumentOutOfRangeException;
 
-public record MaxLengthSpecification(int maxLength) implements Specification<String> {
+public final class MaxLengthSpecification implements Specification<String> {
+    private final int maxLength;
+
+    private MaxLengthSpecification(final int maxLength) {
+        this.maxLength = maxLength;
+    }
+
     public static MaxLengthSpecification of(final int maxLength) {
         return new MaxLengthSpecification(maxLength);
     }

--- a/backend/app/src/main/java/com/kachnic/rtchats/libs/ddd/specs/NotBlankSpecification.java
+++ b/backend/app/src/main/java/com/kachnic/rtchats/libs/ddd/specs/NotBlankSpecification.java
@@ -3,10 +3,8 @@ package com.kachnic.rtchats.libs.ddd.specs;
 import com.kachnic.rtchats.libs.ddd.DomainValidate;
 import com.kachnic.rtchats.libs.ddd.exceptions.MissingArgumentException;
 
-public final class NotBlankSpecification implements Specification<String> {
-    private static final NotBlankSpecification INSTANCE = new NotBlankSpecification();
-
-    private NotBlankSpecification() {}
+public enum NotBlankSpecification implements Specification<String> {
+    INSTANCE;
 
     public static NotBlankSpecification of() {
         return INSTANCE;

--- a/backend/app/src/main/java/com/kachnic/rtchats/libs/ddd/specs/TimeLimitSpecification.java
+++ b/backend/app/src/main/java/com/kachnic/rtchats/libs/ddd/specs/TimeLimitSpecification.java
@@ -1,0 +1,61 @@
+package com.kachnic.rtchats.libs.ddd.specs;
+
+import com.kachnic.rtchats.libs.ddd.exceptions.DomainException;
+import com.kachnic.rtchats.libs.ddd.exceptions.InternalServerException;
+import com.kachnic.rtchats.libs.ddd.exceptions.TimeLimitExceededException;
+import java.util.concurrent.*;
+
+public final class TimeLimitSpecification<T> implements Specification<T> {
+    private final Specification<T> wrappedSpec;
+    private final long timeLimitMs;
+    private static final String MESSAGE_PREFIX = "Timeout exceeded for: ";
+
+    private TimeLimitSpecification(final Specification<T> wrappedSpec, final long timeLimitMs) {
+        this.wrappedSpec = wrappedSpec;
+        this.timeLimitMs = timeLimitMs;
+    }
+
+    public static <T> Specification<T> of(final Specification<T> wrappedSpec, final long timeLimitMs) {
+        return new TimeLimitSpecification<>(wrappedSpec, timeLimitMs);
+    }
+
+    @Override
+    public void check(final T candidate, final String paramName) {
+        @SuppressWarnings("PMD.CloseResource")
+        final ExecutorService commonPool = ForkJoinPool.commonPool();
+
+        final Future<Void> specFuture = commonPool.submit(() -> {
+            wrappedSpec.check(candidate, paramName);
+            return null;
+        });
+
+        try {
+            specFuture.get(timeLimitMs, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException exc) {
+            handleInterrupted(exc, specFuture);
+        } catch (ExecutionException exc) {
+            handleExecution(exc);
+        } catch (TimeoutException exc) {
+            handleTimeout(specFuture, paramName);
+        }
+    }
+
+    private void handleInterrupted(final InterruptedException exc, final Future<Void> specFuture) {
+        Thread.currentThread().interrupt();
+        specFuture.cancel(true);
+        throw new InternalServerException(exc);
+    }
+
+    private void handleExecution(final ExecutionException exc) {
+        final Throwable cause = exc.getCause();
+        if (cause instanceof DomainException domainException) {
+            throw domainException;
+        }
+        throw new InternalServerException(cause);
+    }
+
+    private void handleTimeout(final Future<Void> specFuture, final String paramName) {
+        specFuture.cancel(true);
+        throw new TimeLimitExceededException(MESSAGE_PREFIX + paramName);
+    }
+}

--- a/backend/app/src/main/java/com/kachnic/rtchats/modules/user/EmailSpecification.java
+++ b/backend/app/src/main/java/com/kachnic/rtchats/modules/user/EmailSpecification.java
@@ -1,29 +1,27 @@
 package com.kachnic.rtchats.modules.user;
 
-import com.kachnic.rtchats.libs.ddd.specs.MatchesFormatSpecification;
-import com.kachnic.rtchats.libs.ddd.specs.MaxLengthSpecification;
-import com.kachnic.rtchats.libs.ddd.specs.NotBlankSpecification;
-import com.kachnic.rtchats.libs.ddd.specs.Specification;
+import com.kachnic.rtchats.libs.ddd.specs.*;
 import java.util.regex.Pattern;
 
 final class EmailSpecification {
     private static final int MAX_LENGTH = 128;
     private static final Pattern VALID_PATTERN = Pattern.compile(
             """
-            (?x)         # Enable COMMENTS mode (ignore whitespace and allow comments)
-            ^            # Start of string
-            .+           # Local part
-            @            # At symbol
-            .+           # Domain
-            \\.          # Dot
-            .+           # Top-Level Domain e.g. com, org, net
-            $            # End of string
+            (?x)            # Enable COMMENTS mode (ignore whitespace and allow comments)
+            ^               # Start of string
+            [^\\s@]+        # Local part: 1+ chars that are not whitespace or '@'
+            @               # At symbol
+            [^\\s@]+        # Domain: 1+ chars that are not whitespace or '@'
+            \\.             # Literal dot
+            [^\\s@]{2,}     # Top level domai: at least 2 chars, not whitespace or '@'
+            $               # End of string
             """,
             Pattern.CASE_INSENSITIVE);
+    private static final long TIME_LIMIT_MS = 10L;
 
     private static final Specification<String> DEFAULT = NotBlankSpecification.of()
             .and(MaxLengthSpecification.of(MAX_LENGTH))
-            .and(MatchesFormatSpecification.of(VALID_PATTERN));
+            .and(TimeLimitSpecification.of(MatchesFormatSpecification.of(VALID_PATTERN), TIME_LIMIT_MS));
 
     private EmailSpecification() {}
 

--- a/backend/app/src/main/java/com/kachnic/rtchats/modules/user/EmailSpecification.java
+++ b/backend/app/src/main/java/com/kachnic/rtchats/modules/user/EmailSpecification.java
@@ -17,7 +17,7 @@ final class EmailSpecification {
             $               # End of string
             """,
             Pattern.CASE_INSENSITIVE);
-    private static final long TIME_LIMIT_MS = 10L;
+    private static final long TIME_LIMIT_MS = 50L;
 
     private static final Specification<String> DEFAULT = NotBlankSpecification.of()
             .and(MaxLengthSpecification.of(MAX_LENGTH))

--- a/backend/app/src/main/java/com/kachnic/rtchats/modules/user/UsernameSpecification.java
+++ b/backend/app/src/main/java/com/kachnic/rtchats/modules/user/UsernameSpecification.java
@@ -1,9 +1,6 @@
 package com.kachnic.rtchats.modules.user;
 
-import com.kachnic.rtchats.libs.ddd.specs.BetweenLengthSpecification;
-import com.kachnic.rtchats.libs.ddd.specs.MatchesFormatSpecification;
-import com.kachnic.rtchats.libs.ddd.specs.NotBlankSpecification;
-import com.kachnic.rtchats.libs.ddd.specs.Specification;
+import com.kachnic.rtchats.libs.ddd.specs.*;
 import java.util.regex.Pattern;
 
 final class UsernameSpecification {
@@ -17,10 +14,11 @@ final class UsernameSpecification {
             [a-zA-Z0-9]*     # Following characters: letters and digits, zero or more
             $                 # End of string
             """);
+    private static final long TIME_LIMIT_MS = 50L;
 
     private static final Specification<String> DEFAULT = NotBlankSpecification.of()
             .and(BetweenLengthSpecification.of(MIN_LENGTH, MAX_LENGTH))
-            .and(MatchesFormatSpecification.of(VALID_PATTERN));
+            .and(TimeLimitSpecification.of(MatchesFormatSpecification.of(VALID_PATTERN), TIME_LIMIT_MS));
 
     private UsernameSpecification() {}
 


### PR DESCRIPTION
Add TimeLimitSpecification to limit other specifications.
Enable time limit on username and password to prevent regex backtracking REDOS.
Change singleton NotBlankSpecification to lazy init.
Change records specifications to final classes.