### PR TITLE
Add interrupt and change constant MESSAGE names

### DIFF
--- a/backend/app/src/main/java/com/kachnic/rtchats/libs/ddd/AsyncCommand.java
+++ b/backend/app/src/main/java/com/kachnic/rtchats/libs/ddd/AsyncCommand.java
@@ -18,7 +18,10 @@ public class AsyncCommand<R> implements Command<R> {
     public R getResult() {
         try {
             return future.get();
-        } catch (InterruptedException | ExecutionException e) {
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new InternalServerException(e);
+        } catch (ExecutionException e) {
             throw new InternalServerException(e);
         }
     }

--- a/backend/app/src/main/java/com/kachnic/rtchats/libs/exceptions/ArgumentInvalidFormatException.java
+++ b/backend/app/src/main/java/com/kachnic/rtchats/libs/exceptions/ArgumentInvalidFormatException.java
@@ -6,9 +6,9 @@ public class ArgumentInvalidFormatException extends DomainException {
     @Serial
     private static final long serialVersionUID = 1L;
 
-    private static final String MESSAGE_PREFIX = "Invalid format for argument: ";
+    private static final String MSG_PREFIX = "Invalid format for argument: ";
 
     public ArgumentInvalidFormatException(final String parameterName, final String invalidValue) {
-        super(MESSAGE_PREFIX + parameterName + " = " + invalidValue);
+        super(MSG_PREFIX + parameterName + " = " + invalidValue);
     }
 }

--- a/backend/app/src/main/java/com/kachnic/rtchats/libs/exceptions/InternalServerException.java
+++ b/backend/app/src/main/java/com/kachnic/rtchats/libs/exceptions/InternalServerException.java
@@ -6,9 +6,9 @@ public class InternalServerException extends DomainException {
     @Serial
     private static final long serialVersionUID = 1L;
 
-    private static final String MESSAGE = "Internal Server Error";
+    private static final String MSG = "Internal Server Error";
 
     public InternalServerException(final Throwable cause) {
-        super(MESSAGE, cause);
+        super(MSG, cause);
     }
 }


### PR DESCRIPTION
Adding Thread.currentThread().interrupt() preserves the thread’s interrupted status, allowing higher-level code to detect and handle the interruption properly.
Change MESSAGE constants to MSG to be consistent in naming.