### PR TITLE
Improve user jpa 

### DIFF
--- a/backend/app/src/main/java/com/kachnic/rtchats/modules/user/domain/model/valueobjects/EmailSpecification.java
+++ b/backend/app/src/main/java/com/kachnic/rtchats/modules/user/domain/model/valueobjects/EmailSpecification.java
@@ -4,7 +4,7 @@ import com.kachnic.rtchats.libs.specs.*;
 import java.util.regex.Pattern;
 
 final class EmailSpecification {
-    private static final int MAX_LENGTH = 128;
+    private static final int MAX_LENGTH = 255;
     private static final Pattern VALID_PATTERN = Pattern.compile(
             """
             (?x)            # Enable COMMENTS mode (ignore whitespace and allow comments)

--- a/backend/app/src/main/java/com/kachnic/rtchats/modules/user/domain/model/valueobjects/PasswordSpecification.java
+++ b/backend/app/src/main/java/com/kachnic/rtchats/modules/user/domain/model/valueobjects/PasswordSpecification.java
@@ -1,10 +1,13 @@
 package com.kachnic.rtchats.modules.user.domain.model.valueobjects;
 
+import com.kachnic.rtchats.libs.specs.MaxLengthSpecification;
 import com.kachnic.rtchats.libs.specs.NotBlankSpecification;
 import com.kachnic.rtchats.libs.specs.Specification;
 
 final class PasswordSpecification {
-    private static final Specification<String> DEFAULT = NotBlankSpecification.of();
+    private static final int MAX_LENGTH = 255;
+    private static final Specification<String> DEFAULT =
+            NotBlankSpecification.of().and(MaxLengthSpecification.of(MAX_LENGTH));
 
     private PasswordSpecification() {}
 

--- a/backend/app/src/main/java/com/kachnic/rtchats/modules/user/infrastructure/DefaultUserRepository.java
+++ b/backend/app/src/main/java/com/kachnic/rtchats/modules/user/infrastructure/DefaultUserRepository.java
@@ -9,6 +9,7 @@ import java.util.Locale;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -16,6 +17,11 @@ import org.springframework.stereotype.Repository;
 class DefaultUserRepository implements UserRepository {
     private final UserCrudRepo userCrudRepo;
     private final UserJpaMapper mapper;
+    private final JdbcTemplate jdbcTemplate;
+
+    @SuppressWarnings("PMD.LongVariable")
+    private static final String SQL_EXISTS_BY_NORMALIZED_EMAIL =
+            "SELECT EXISTS (SELECT 1 FROM users WHERE normalized_email = ?)";
 
     @Override
     public UserId nextId() {
@@ -37,6 +43,8 @@ class DefaultUserRepository implements UserRepository {
     @Override
     public boolean existsByEmail(final Email email) {
         final String normalizedEmail = email.value().toLowerCase(Locale.ROOT);
-        return userCrudRepo.existsByNormalizedEmail(normalizedEmail);
+        final Boolean result =
+                jdbcTemplate.queryForObject(SQL_EXISTS_BY_NORMALIZED_EMAIL, Boolean.class, normalizedEmail);
+        return Boolean.TRUE.equals(result);
     }
 }

--- a/backend/app/src/main/java/com/kachnic/rtchats/modules/user/infrastructure/DefaultUserRepository.java
+++ b/backend/app/src/main/java/com/kachnic/rtchats/modules/user/infrastructure/DefaultUserRepository.java
@@ -5,6 +5,7 @@ import com.kachnic.rtchats.modules.user.domain.UserEntity;
 import com.kachnic.rtchats.modules.user.domain.UserRepository;
 import com.kachnic.rtchats.modules.user.domain.model.valueobjects.Email;
 import com.kachnic.rtchats.modules.user.domain.model.valueobjects.UserId;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
@@ -23,7 +24,8 @@ class DefaultUserRepository implements UserRepository {
 
     @Override
     public Optional<UserDto> findByEmail(final Email email) {
-        return userCrudRepo.findByEmailIgnoreCase(email.value()).map(mapper::toDto);
+        final String normalizedEmail = email.value().toLowerCase(Locale.ROOT);
+        return userCrudRepo.findByNormalizedEmail(normalizedEmail).map(mapper::toDto);
     }
 
     @Override
@@ -34,6 +36,7 @@ class DefaultUserRepository implements UserRepository {
 
     @Override
     public boolean existsByEmail(final Email email) {
-        return userCrudRepo.existsByEmailIgnoreCase(email.value());
+        final String normalizedEmail = email.value().toLowerCase(Locale.ROOT);
+        return userCrudRepo.existsByNormalizedEmail(normalizedEmail);
     }
 }

--- a/backend/app/src/main/java/com/kachnic/rtchats/modules/user/infrastructure/UserCrudRepo.java
+++ b/backend/app/src/main/java/com/kachnic/rtchats/modules/user/infrastructure/UserCrudRepo.java
@@ -5,7 +5,7 @@ import java.util.UUID;
 import org.springframework.data.repository.CrudRepository;
 
 interface UserCrudRepo extends CrudRepository<UserJpa, UUID> {
-    boolean existsByEmailIgnoreCase(String email);
+    boolean existsByNormalizedEmail(String normalizedEmail);
 
-    Optional<UserJpa> findByEmailIgnoreCase(String email);
+    Optional<UserJpa> findByNormalizedEmail(String normalizedEmail);
 }

--- a/backend/app/src/main/java/com/kachnic/rtchats/modules/user/infrastructure/UserCrudRepo.java
+++ b/backend/app/src/main/java/com/kachnic/rtchats/modules/user/infrastructure/UserCrudRepo.java
@@ -5,7 +5,5 @@ import java.util.UUID;
 import org.springframework.data.repository.CrudRepository;
 
 interface UserCrudRepo extends CrudRepository<UserJpa, UUID> {
-    boolean existsByNormalizedEmail(String normalizedEmail);
-
     Optional<UserJpa> findByNormalizedEmail(String normalizedEmail);
 }

--- a/backend/app/src/main/java/com/kachnic/rtchats/modules/user/infrastructure/UserJpa.java
+++ b/backend/app/src/main/java/com/kachnic/rtchats/modules/user/infrastructure/UserJpa.java
@@ -6,22 +6,32 @@ import java.util.UUID;
 import lombok.*;
 
 @Entity
-@Table(name = "users")
+@Table(
+        name = "users",
+        indexes = {@Index(name = "users_idx_normalized_email", columnList = "normalizedEmail")})
 @Getter
 @Setter
 @NoArgsConstructor
 class UserJpa {
 
     @Id
+    @Column(nullable = false, updatable = false)
     private UUID userId;
 
+    @Column(nullable = false, unique = true)
     private String email;
 
+    @Column(nullable = false, unique = true)
     private String normalizedEmail;
 
+    @Column(nullable = false, length = 32)
     private String username;
 
+    @Column(nullable = false)
     private String password;
+
+    @Version
+    private long version;
 
     @PrePersist
     @PreUpdate

--- a/backend/app/src/main/java/com/kachnic/rtchats/modules/user/infrastructure/UserJpa.java
+++ b/backend/app/src/main/java/com/kachnic/rtchats/modules/user/infrastructure/UserJpa.java
@@ -1,8 +1,7 @@
 package com.kachnic.rtchats.modules.user.infrastructure;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
+import java.util.Locale;
 import java.util.UUID;
 import lombok.*;
 
@@ -11,7 +10,6 @@ import lombok.*;
 @Getter
 @Setter
 @NoArgsConstructor
-@AllArgsConstructor
 class UserJpa {
 
     @Id
@@ -19,7 +17,15 @@ class UserJpa {
 
     private String email;
 
+    private String normalizedEmail;
+
     private String username;
 
     private String password;
+
+    @PrePersist
+    @PreUpdate
+    /* package */ void normalizeEmail() {
+        normalizedEmail = email.toLowerCase(Locale.ROOT);
+    }
 }

--- a/backend/app/src/main/java/com/kachnic/rtchats/modules/user/infrastructure/UserMapper.java
+++ b/backend/app/src/main/java/com/kachnic/rtchats/modules/user/infrastructure/UserMapper.java
@@ -34,6 +34,7 @@ interface UserJpaMapper {
     @Mapping(source = "entityId", target = "userId")
     @Mapping(source = "userInfo", target = ".")
     @Mapping(target = "normalizedEmail", ignore = true)
+    @Mapping(target = "version", ignore = true)
     UserJpa toPersistence(UserEntity entity);
 
     UserDto toDto(UserJpa userJpa);

--- a/backend/app/src/main/java/com/kachnic/rtchats/modules/user/infrastructure/UserMapper.java
+++ b/backend/app/src/main/java/com/kachnic/rtchats/modules/user/infrastructure/UserMapper.java
@@ -33,6 +33,7 @@ interface UserMapper extends UserEntityMapper, UserJpaMapper {
 interface UserJpaMapper {
     @Mapping(source = "entityId", target = "userId")
     @Mapping(source = "userInfo", target = ".")
+    @Mapping(target = "normalizedEmail", ignore = true)
     UserJpa toPersistence(UserEntity entity);
 
     UserDto toDto(UserJpa userJpa);

--- a/backend/app/src/main/resources/application-dev.properties
+++ b/backend/app/src/main/resources/application-dev.properties
@@ -7,7 +7,9 @@ spring.datasource.username=${DEV_DB_USER:dev_user}
 spring.datasource.password=${DEV_DB_PASS:dev_pass}
 
 spring.jpa.hibernate.ddl-auto=update
-spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+
+
 
 # Server
 server.port=${DEV_SERVER_PORT:8080}
@@ -15,3 +17,5 @@ server.port=${DEV_SERVER_PORT:8080}
 # Logging
 logging.level.web=DEBUG
 logging.level.org.springframework.security=DEBUG
+logging.level.org.hibernate.SQL=DEBUG
+logging.level.org.springframework.jdbc.core.JdbcTemplate=DEBUG


### PR DESCRIPTION
Update the User model to store a provided email and a normalized version.
Add proper constraints to the User model.
Use JdbcTemplate to replace JPA existence checks for improved performance. 
Add a unique index on the normalized email field to ensure fast lookups.
Enhance SQL logging to simplify debugging.